### PR TITLE
Update ReadME.md update discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Arcturus Morningstar is as a fork of Arcturus Emulator by TheGeneral. Arcturus M
 
 
 
-[![image](https://img.shields.io/discord/557240155040251905?style=for-the-badge&logo=discord&color=7289DA&label=KREWS&logoColor=fff)](https://discord.gg/BzfFsTp)
+[![image](https://img.shields.io/discord/1009567470476087388?style=for-the-badge&logo=discord&color=7289DA&label=KREWS&logoColor=fff)](https://discord.gg/rszGmsFm)
 
 ## Download ##
 [![image](https://img.shields.io/badge/STABLE%20RELEASES-3.5.1-success.svg?style=for-the-badge&logo=appveyor)](https://git.krews.org/morningstar/Arcturus-Community/-/releases)


### PR DESCRIPTION
In GitLab by @Harmony on Dec 5, 2022, 12:11

Update ReadME.md to use the new Krews discord as the previous one has been turned into a money making scheme and home for scams/pedos by it's 'caretaker' admin.