### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ COPY . .
 # Package it
 RUN mvn package && mv /target/Habbo*-with-dependencies.jar /target/Habbo.jar
 
-# Use Java 8 for running
-FROM java:8 AS runner
+# Use Java 11 for running
+FROM openjdk:11 AS runner
 
 # Copy the generated source
 COPY --from=builder /target/Habbo.jar /


### PR DESCRIPTION
java:8 is not available as docker image anymore.

Changing it to openjdk:11 for quick fix, however openjdk is deprecated too, see https://hub.docker.com/_/openjdk